### PR TITLE
Added CachingCompanionObjectAccordValidatorResolver (fixes #94)

### DIFF
--- a/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorResolver.scala
+++ b/spring3/src/main/scala/com/wix/accord/spring/AccordValidatorResolver.scala
@@ -89,7 +89,7 @@ trait AccordValidatorResolverCache extends AccordValidatorResolver {
 
   abstract override def lookupValidator[ T : ClassTag ]: Option[ Validator[ T ] ] = {
     val clazz = implicitly[ ClassTag[ T ] ].runtimeClass
-    memoizedLookups.getOrElseUpdate(clazz, super.lookupValidator[ T ]).map {
+    memoizedLookups.getOrElseUpdate( clazz, super.lookupValidator[ T ] ).map {
       _.asInstanceOf[ Validator[ T ] ]
     }
   }

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
@@ -1,0 +1,79 @@
+package com.wix.accord.spring
+
+import com.wix.accord.Validator
+import com.wix.accord.dsl._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.reflect.ClassTag
+
+class AccordValidatorResolverCacheTest extends WordSpec with Matchers {
+
+  import AccordValidatorResolverCacheTest._
+
+  "AccordValidatorResolverCache" should {
+
+    def newResolver = new CachedTestValidatorResolver
+
+    "return None when the class has no validator defined" in {
+      newResolver.lookupValidator[ Class1 ] shouldBe empty
+    }
+
+    "return the validator when it is defined" in {
+      val resolver = newResolver
+      resolver.setLookupResult(validator1)
+      resolver.lookupValidator[ Class1 ] should contain(validator1)
+    }
+
+    "consistently resolve validators for different classes" in {
+      val resolver = newResolver
+
+      resolver.setLookupResult(validator1)
+      resolver.lookupValidator[ Class1 ]
+
+      resolver.setLookupResult(validator2)
+      resolver.lookupValidator[ Class2 ]
+
+      resolver.lookupValidator[ Class1 ] should contain(validator1)
+      resolver.lookupValidator[ Class2 ] should contain(validator2)
+    }
+
+    "perform validator lookup for the same class only once" in {
+      val resolver = newResolver
+      resolver.lookupValidator[ Class1 ]
+      resolver.lookupValidator[ Class1 ]
+      resolver.invocationCount shouldBe 1
+    }
+  }
+}
+
+object AccordValidatorResolverCacheTest {
+
+  class TestValidatorResolver extends AccordValidatorResolver {
+
+    private var invocationCounter = 0
+    private var lookupResult: Option[ Validator[_] ] = None
+
+    override def lookupValidator[ T : ClassTag ]: Option[ Validator [ T ] ] = {
+      invocationCounter += 1
+      lookupResult.map {
+        _.asInstanceOf[ Validator[ T ] ]
+      }
+    }
+
+    def setLookupResult(result: Validator[_]) = {
+      lookupResult = Some(result)
+    }
+
+    def invocationCount = invocationCounter
+  }
+
+  class CachedTestValidatorResolver extends TestValidatorResolver with AccordValidatorResolverCache
+
+  class Class1
+
+  class Class2
+
+  val validator1 = validator[ Int ] { _ should be > 1 }
+
+  val validator2 = validator[ Int ] { _ should be > 2 }
+}

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
@@ -20,21 +20,21 @@ class AccordValidatorResolverCacheTest extends WordSpec with Matchers {
 
     "return the validator when it is defined" in {
       val resolver = newResolver
-      resolver.setLookupResult(validator1)
-      resolver.lookupValidator[ Class1 ] shouldBe Some(validator1)
+      resolver.setLookupResult( validator1 )
+      resolver.lookupValidator[ Class1 ] shouldBe Some( validator1 )
     }
 
     "consistently resolve validators for different classes" in {
       val resolver = newResolver
 
-      resolver.setLookupResult(validator1)
+      resolver.setLookupResult( validator1 )
       resolver.lookupValidator[ Class1 ]
 
-      resolver.setLookupResult(validator2)
+      resolver.setLookupResult( validator2 )
       resolver.lookupValidator[ Class2 ]
 
-      resolver.lookupValidator[ Class1 ] shouldBe Some(validator1)
-      resolver.lookupValidator[ Class2 ] shouldBe Some(validator2)
+      resolver.lookupValidator[ Class1 ] shouldBe Some( validator1 )
+      resolver.lookupValidator[ Class2 ] shouldBe Some( validator2 )
     }
 
     "perform validator lookup for the same class only once" in {
@@ -55,13 +55,11 @@ object AccordValidatorResolverCacheTest {
 
     override def lookupValidator[ T : ClassTag ]: Option[ Validator [ T ] ] = {
       invocationCounter += 1
-      lookupResult.map {
-        _.asInstanceOf[ Validator[ T ] ]
-      }
+      lookupResult.map { _.asInstanceOf[ Validator[ T ] ] }
     }
 
-    def setLookupResult(result: Validator[_]) = {
-      lookupResult = Some(result)
+    def setLookupResult( result: Validator[_] ) = {
+      lookupResult = Some( result )
     }
 
     def invocationCount = invocationCounter

--- a/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/AccordValidatorResolverCacheTest.scala
@@ -21,7 +21,7 @@ class AccordValidatorResolverCacheTest extends WordSpec with Matchers {
     "return the validator when it is defined" in {
       val resolver = newResolver
       resolver.setLookupResult(validator1)
-      resolver.lookupValidator[ Class1 ] should contain(validator1)
+      resolver.lookupValidator[ Class1 ] shouldBe Some(validator1)
     }
 
     "consistently resolve validators for different classes" in {
@@ -33,8 +33,8 @@ class AccordValidatorResolverCacheTest extends WordSpec with Matchers {
       resolver.setLookupResult(validator2)
       resolver.lookupValidator[ Class2 ]
 
-      resolver.lookupValidator[ Class1 ] should contain(validator1)
-      resolver.lookupValidator[ Class2 ] should contain(validator2)
+      resolver.lookupValidator[ Class1 ] shouldBe Some(validator1)
+      resolver.lookupValidator[ Class2 ] shouldBe Some(validator2)
     }
 
     "perform validator lookup for the same class only once" in {

--- a/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
@@ -25,7 +25,7 @@ trait CompanionObjectValidatorResolverBehaviors extends Matchers with ResultMatc
 
   import CompanionObjectAccordValidatorResolverTest._
 
-  def companionObjectValidatorResolver(newResolver: => AccordValidatorResolver) = {
+  def companionObjectValidatorResolver( newResolver: => AccordValidatorResolver ) = {
 
     "successfully resolve a validator when available on a test class companion" in {
       val resolved = newResolver.lookupValidator[ Test1 ]
@@ -54,11 +54,11 @@ trait CompanionObjectValidatorResolverBehaviors extends Matchers with ResultMatc
 class CompanionObjectAccordValidatorResolverTest extends WordSpec with CompanionObjectValidatorResolverBehaviors {
 
   "CompanionObjectAccordValidatorResolver" should {
-    behave like companionObjectValidatorResolver(new CompanionObjectAccordValidatorResolver)
+    behave like companionObjectValidatorResolver( new CompanionObjectAccordValidatorResolver )
   }
 
   "CachingCompanionObjectAccordValidatorResolver" should {
-    behave like companionObjectValidatorResolver(new CachingCompanionObjectAccordValidatorResolver)
+    behave like companionObjectValidatorResolver( new CachingCompanionObjectAccordValidatorResolver )
   }
 }
 

--- a/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
+++ b/spring3/src/test/scala/com/wix/accord/spring/CompanionObjectAccordValidatorResolverTest.scala
@@ -20,16 +20,15 @@ import com.wix.accord._
 import org.scalatest.{WordSpec, Matchers}
 import com.wix.accord.scalatest.ResultMatchers
 
-class CompanionObjectAccordValidatorResolverTest extends WordSpec with Matchers with ResultMatchers {
+trait CompanionObjectValidatorResolverBehaviors extends Matchers with ResultMatchers {
+  this: WordSpec =>
 
   import CompanionObjectAccordValidatorResolverTest._
 
-  "CompanionObjectAccordResolver" should {
-
-    def resolver = new CompanionObjectAccordValidatorResolver
+  def companionObjectValidatorResolver(newResolver: => AccordValidatorResolver) = {
 
     "successfully resolve a validator when available on a test class companion" in {
-      val resolved = resolver.lookupValidator[ Test1 ]
+      val resolved = newResolver.lookupValidator[ Test1 ]
       resolved should not be empty
 
       // Quick sanity tests to make sure the resolved validator is functional
@@ -41,11 +40,26 @@ class CompanionObjectAccordValidatorResolverTest extends WordSpec with Matchers 
     }
 
     "return None when no validator is available on the test class companion" in {
-      val resolved = resolver.lookupValidator[ Test2 ]
+      val resolved = newResolver.lookupValidator[ Test2 ]
+      resolved shouldBe empty
+    }
+
+    "return None when the test class has no companion object" in {
+      val resolved = newResolver.lookupValidator[ Test3 ]
       resolved shouldBe empty
     }
   }
+}
 
+class CompanionObjectAccordValidatorResolverTest extends WordSpec with CompanionObjectValidatorResolverBehaviors {
+
+  "CompanionObjectAccordValidatorResolver" should {
+    behave like companionObjectValidatorResolver(new CompanionObjectAccordValidatorResolver)
+  }
+
+  "CachingCompanionObjectAccordValidatorResolver" should {
+    behave like companionObjectValidatorResolver(new CachingCompanionObjectAccordValidatorResolver)
+  }
 }
 
 object CompanionObjectAccordValidatorResolverTest {
@@ -58,5 +72,7 @@ object CompanionObjectAccordValidatorResolverTest {
 
   case class Test2( x: String )
   case object Test2
+
+  class Test3( x: String )
 }
 


### PR DESCRIPTION
Added CachingCompanionObjectAccordValidatorResolver which implements validator lookup memoization on top of the existing CompanionObjectAccordValidatorResolver. Memoization covers all invocations, including cases when companion object does not exist.